### PR TITLE
Allow override of url and headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-sse-client",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "description": "A Node Red node to receive Server Sent events",
     "dependencies": {
         "original": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,28 @@
 {
-    "name"         : "node-red-contrib-sse-client",
-    "version"      : "0.0.1",
-    "description"  : "A Node Red node to receive Server Sent events",
+    "name": "node-red-contrib-sse-client",
+    "version": "0.0.1",
+    "description": "A Node Red node to receive Server Sent events",
     "dependencies": {
-       "original": "^1.0.0"
+        "original": "^1.0.0"
     },
     "author": {
         "name": "Bart Butenaers"
     },
+    "contributors": [
+        {
+            "name": "Jochen Scheib",
+            "url": "https://github.com/mapero"
+        }
+    ],
     "license": "Apache-2.0",
-    "keywords": [ "node-red", "sse", "server", "client", "event", "stream" ],
+    "keywords": [
+        "node-red",
+        "sse",
+        "server",
+        "client",
+        "event",
+        "stream"
+    ],
     "bugs": {
         "url": "https://github.com/bartbutenaers/node-red-contrib-sse-client/issues"
     },
@@ -18,7 +31,7 @@
         "type": "git",
         "url": "https://github.com/bartbutenaers/node-red-contrib-sse-client.git"
     },
-    "node-red"     : {
+    "node-red": {
         "nodes": {
             "sse-client": "sse_client.js"
         }

--- a/sse_client.html
+++ b/sse_client.html
@@ -193,11 +193,11 @@
 
 <script type="text/x-red" data-help-name="sse-client">
     <p>Node-Red node to receive SSE events from a server.</p>
-    <p><strong>Url:</strong><br/>
+    <p><strong>Url (msg.url):</strong><br/>
     The URL of the event source, i.e. the server that sends SSE events to this client.</p>
     <p><strong>Events:</strong><br/>
     The list of all SSE events that we want to receive.  Specify at least 1 event.</p>
-    <p><strong>Http headers:</strong><br/>
+    <p><strong>Http headers (msg.headers):</strong><br/>
     The (optional) list of all http headers that should be send in the initial http request to the server. See <a href="https://en.wikipedia.org/wiki/List_of_HTTP_header_fields" target="_blank">here</a> for a list of possible headers.</p>
     <p><strong>Proxy:</strong><br/>
     The (optional) proxy url, in case the client is located behind a corporate firewall.</p>

--- a/sse_client.html
+++ b/sse_client.html
@@ -53,7 +53,7 @@
         color:    'rgb(231, 231, 174)',
         defaults: {
             name: {value: ""},
-            url: {value:"", required:true, validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
+            url: {value:"", required:false, validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
             events: {value: [], required:true},
             partHeaders: {value:{}},
             proxy: {value:"",required:false},


### PR DESCRIPTION
Hi bart,

I have the need to override some of the nodes properties dynamically without redeployment. E.g. the Authroization header with the new access token after one day.

This pull request allows the override of the headers and url via msg.url and msg.headers.

It would be kind to merge the change and publish to npm.

Thank you.

Regards
Jochen